### PR TITLE
Add browser-based travel map animator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ python -m travelmap.main travelmap/examples/sample_trip.json
 
 The resulting video is written to the `output` path defined in your configuration file.
 
+## Browser-based animator
+
+A lightweight web interface is bundled in the [`web/`](web/) directory. Serve the folder with any static file server (for example `python -m http.server` from the repository root) and open `http://localhost:8000/web/` in your browser. The page lets you:
+
+- Load an existing itinerary JSON file that matches the CLI configuration schema.
+- Add or remove waypoints manually and adjust animation settings such as speed, frame rate and pauses.
+- Upload a custom PNG vehicle icon and preview it instantly.
+- Preview the animation directly on the page or record it to a downloadable WebM file using the browser's `MediaRecorder` API.
+
+> **Note:** Downloading animations requires a browser that supports the Canvas `captureStream()` API and the `MediaRecorder` API (Chrome, Edge and Firefox). Safari currently allows previewing but not exporting.
+
 ### Configuration schema
 
 | Field | Type | Description |

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,773 @@
+const DEFAULT_ICON_COLOUR = "#53a9ff";
+const CONTINENT_SHAPES = {
+  north_america: [
+    [83.0, -95.0],
+    [70.0, -168.0],
+    [50.0, -170.0],
+    [23.0, -100.0],
+    [7.0, -83.0],
+    [18.0, -64.0],
+    [32.0, -81.0],
+    [50.0, -60.0],
+    [60.0, -64.0],
+    [70.0, -70.0],
+    [83.0, -95.0],
+  ],
+  south_america: [
+    [12.0, -81.0],
+    [5.0, -75.0],
+    [-15.0, -75.0],
+    [-33.0, -69.0],
+    [-55.0, -67.0],
+    [-55.0, -47.0],
+    [-30.0, -40.0],
+    [-12.0, -38.0],
+    [4.0, -50.0],
+    [12.0, -60.0],
+    [12.0, -81.0],
+  ],
+  europe_asia: [
+    [72.0, -10.0],
+    [70.0, 40.0],
+    [55.0, 85.0],
+    [50.0, 120.0],
+    [58.0, 160.0],
+    [50.0, 180.0],
+    [10.0, 140.0],
+    [5.0, 100.0],
+    [25.0, 50.0],
+    [35.0, 30.0],
+    [45.0, 10.0],
+    [60.0, -10.0],
+    [72.0, -10.0],
+  ],
+  africa: [
+    [35.0, -17.0],
+    [31.0, 30.0],
+    [12.0, 43.0],
+    [0.0, 46.0],
+    [-25.0, 32.0],
+    [-35.0, 20.0],
+    [-35.0, 15.0],
+    [-22.0, 11.0],
+    [-5.0, 10.0],
+    [16.0, -5.0],
+    [20.0, -17.0],
+    [35.0, -17.0],
+  ],
+  australia: [
+    [-11.0, 113.0],
+    [-12.0, 129.0],
+    [-23.0, 153.0],
+    [-36.0, 149.0],
+    [-43.0, 146.0],
+    [-39.0, 135.0],
+    [-34.0, 115.0],
+    [-17.0, 113.0],
+    [-11.0, 113.0],
+  ],
+  antarctica: [
+    [-60.0, -180.0],
+    [-60.0, -90.0],
+    [-60.0, 0.0],
+    [-60.0, 90.0],
+    [-60.0, 180.0],
+    [-80.0, 180.0],
+    [-80.0, -180.0],
+    [-60.0, -180.0],
+  ],
+};
+
+const state = {
+  waypoints: [],
+  iconImage: null,
+  iconScale: 1,
+  timeline: null,
+  animation: null,
+  projectedWaypoints: [],
+  bounds: null,
+  heading: 0,
+};
+
+const canvas = document.getElementById("mapCanvas");
+const ctx = canvas.getContext("2d");
+const iconCanvas = document.getElementById("iconPreview");
+const iconCtx = iconCanvas.getContext("2d");
+const waypointTableBody = document.querySelector("#waypointTable tbody");
+const waypointRowTemplate = document.getElementById("waypointRowTemplate");
+const statusEl = document.getElementById("status");
+const downloadPreview = document.getElementById("downloadPreview");
+
+const titleInput = document.getElementById("titleInput");
+const speedInput = document.getElementById("speedInput");
+const frameRateInput = document.getElementById("frameRateInput");
+const startPauseInput = document.getElementById("startPauseInput");
+const endPauseInput = document.getElementById("endPauseInput");
+
+const previewButton = document.getElementById("previewButton");
+const downloadButton = document.getElementById("downloadButton");
+
+function setStatus(text, type = "info") {
+  statusEl.textContent = text;
+  statusEl.dataset.type = type;
+}
+
+function renderIconPreview() {
+  iconCtx.clearRect(0, 0, iconCanvas.width, iconCanvas.height);
+  iconCtx.save();
+  iconCtx.translate(iconCanvas.width / 2, iconCanvas.height / 2);
+  if (state.iconImage) {
+    const scale = state.iconScale;
+    const size = Math.min(iconCanvas.width, iconCanvas.height) * 0.8 * scale;
+    iconCtx.drawImage(state.iconImage, -size / 2, -size / 2, size, size);
+  } else {
+    const radius = Math.min(iconCanvas.width, iconCanvas.height) * 0.35;
+    const gradient = iconCtx.createRadialGradient(0, 0, radius * 0.35, 0, 0, radius);
+    gradient.addColorStop(0, "#8fd3ff");
+    gradient.addColorStop(1, DEFAULT_ICON_COLOUR);
+    iconCtx.fillStyle = gradient;
+    iconCtx.beginPath();
+    iconCtx.arc(0, 0, radius, 0, Math.PI * 2);
+    iconCtx.fill();
+    iconCtx.fillStyle = "rgba(0, 0, 0, 0.65)";
+    iconCtx.font = "bold 32px 'Inter', system-ui";
+    iconCtx.textAlign = "center";
+    iconCtx.textBaseline = "middle";
+    iconCtx.fillText("GO", 0, 0);
+  }
+  iconCtx.restore();
+}
+
+function renderWaypointTable() {
+  waypointTableBody.innerHTML = "";
+  state.waypoints.forEach((wp, index) => {
+    const row = waypointRowTemplate.content.firstElementChild.cloneNode(true);
+    row.querySelector(".index").textContent = String(index + 1);
+    row.querySelector(".name").textContent = wp.name || "(untitled)";
+    row.querySelector(".lat").textContent = Number(wp.lat).toFixed(4);
+    row.querySelector(".lon").textContent = Number(wp.lon).toFixed(4);
+    row.querySelector(".pause").textContent = Number(wp.pause || 0).toFixed(1);
+    row.querySelector(".remove").addEventListener("click", () => {
+      state.waypoints.splice(index, 1);
+      renderWaypointTable();
+      drawStaticMap();
+    });
+    waypointTableBody.appendChild(row);
+  });
+}
+
+function handleWaypointSubmit(event) {
+  event.preventDefault();
+  const name = document.getElementById("waypointName").value.trim();
+  const lat = parseFloat(document.getElementById("waypointLat").value);
+  const lon = parseFloat(document.getElementById("waypointLon").value);
+  const pause = parseFloat(document.getElementById("waypointPause").value || "0");
+  if (Number.isNaN(lat) || Number.isNaN(lon)) {
+    setStatus("Latitude and longitude must be valid numbers.", "error");
+    return;
+  }
+  state.waypoints.push({ name, lat, lon, pause });
+  event.target.reset();
+  document.getElementById("waypointPause").value = "1";
+  renderWaypointTable();
+  drawStaticMap();
+  setStatus("Waypoints updated.");
+}
+
+document.getElementById("waypointForm").addEventListener("submit", handleWaypointSubmit);
+
+document.getElementById("configUpload").addEventListener("change", async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const config = JSON.parse(text);
+    applyConfiguration(config);
+    setStatus(`Loaded configuration from ${file.name}.`);
+  } catch (error) {
+    console.error(error);
+    setStatus("Unable to read configuration file.", "error");
+  }
+});
+
+document.getElementById("iconUpload").addEventListener("change", async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) {
+    state.iconImage = null;
+    renderIconPreview();
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = () => {
+    const img = new Image();
+    img.onload = () => {
+      state.iconImage = img;
+      state.iconScale = 1;
+      renderIconPreview();
+      drawStaticMap();
+      setStatus(`Loaded icon (${file.name}).`);
+    };
+    img.src = reader.result;
+  };
+  reader.onerror = () => {
+    setStatus("Unable to read icon file.", "error");
+  };
+  reader.readAsDataURL(file);
+});
+
+function applyConfiguration(config) {
+  titleInput.value = config.title || "";
+  speedInput.value = config.speed_kmh || 80;
+  frameRateInput.value = config.frame_rate || 30;
+  startPauseInput.value = config.pause_at_start ?? 1;
+  endPauseInput.value = config.pause_at_end ?? 1;
+
+  state.iconScale = config.vehicle?.icon_scale || 1;
+  if (config.vehicle?.icon) {
+    tryLoadIcon(config.vehicle.icon);
+  }
+
+  state.waypoints = Array.isArray(config.waypoints)
+    ? config.waypoints.map((wp) => ({
+        name: wp.name || "",
+        lat: parseFloat(wp.lat),
+        lon: parseFloat(wp.lon),
+        pause: parseFloat(wp.pause || 0),
+      }))
+    : [];
+  renderWaypointTable();
+  drawStaticMap();
+}
+
+async function tryLoadIcon(path) {
+  try {
+    const response = await fetch(path);
+    if (!response.ok) throw new Error("Request failed");
+    const blob = await response.blob();
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        state.iconImage = img;
+        renderIconPreview();
+        drawStaticMap();
+      };
+      img.src = reader.result;
+    };
+    reader.readAsDataURL(blob);
+  } catch (error) {
+    console.warn("Unable to load icon from configuration", error);
+    setStatus("Icon path could not be loaded in the browser.", "warning");
+    state.iconImage = null;
+    renderIconPreview();
+  }
+}
+
+function computeBounds(marginDegrees = 6) {
+  if (!state.waypoints.length) {
+    return {
+      minLat: -60,
+      maxLat: 80,
+      minLon: -140,
+      maxLon: 160,
+    };
+  }
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLon = Infinity;
+  let maxLon = -Infinity;
+  state.waypoints.forEach((wp) => {
+    if (!Number.isFinite(wp.lat) || !Number.isFinite(wp.lon)) {
+      return;
+    }
+    minLat = Math.min(minLat, wp.lat);
+    maxLat = Math.max(maxLat, wp.lat);
+    minLon = Math.min(minLon, wp.lon);
+    maxLon = Math.max(maxLon, wp.lon);
+  });
+  return {
+    minLat: minLat - marginDegrees,
+    maxLat: maxLat + marginDegrees,
+    minLon: minLon - marginDegrees,
+    maxLon: maxLon + marginDegrees,
+  };
+}
+
+function project(lat, lon, bounds) {
+  const { minLat, maxLat, minLon, maxLon } = bounds;
+  const lonRange = Math.max(maxLon - minLon, 0.0001);
+  const latRange = Math.max(maxLat - minLat, 0.0001);
+  const x = ((lon - minLon) / lonRange) * canvas.width;
+  const y = ((maxLat - lat) / latRange) * canvas.height;
+  return { x, y };
+}
+
+function drawStaticMap() {
+  const bounds = computeBounds();
+  state.bounds = bounds;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, "#021224");
+  gradient.addColorStop(1, "#031a2f");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.save();
+  ctx.globalAlpha = 0.6;
+  ctx.fillStyle = "#142d47";
+  Object.values(CONTINENT_SHAPES).forEach((shape) => {
+    ctx.beginPath();
+    shape.forEach(([lat, lon], index) => {
+      const { x, y } = project(lat, lon, bounds);
+      if (index === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.closePath();
+    ctx.fill();
+  });
+  ctx.restore();
+
+  if (!state.waypoints.length) return;
+
+  state.projectedWaypoints = state.waypoints.map((wp) => ({
+    ...wp,
+    ...project(wp.lat, wp.lon, bounds),
+  }));
+
+  ctx.strokeStyle = "rgba(143, 211, 255, 0.25)";
+  ctx.lineWidth = 4;
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  state.projectedWaypoints.forEach((pt, index) => {
+    if (index === 0) ctx.moveTo(pt.x, pt.y);
+    else ctx.lineTo(pt.x, pt.y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = "#8fd3ff";
+  ctx.strokeStyle = "rgba(12, 42, 70, 0.7)";
+  ctx.lineWidth = 2;
+  state.projectedWaypoints.forEach((pt) => {
+    ctx.beginPath();
+    ctx.arc(pt.x, pt.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.85)";
+  ctx.font = "600 20px 'Inter', system-ui";
+  ctx.textAlign = "left";
+  ctx.fillText(titleInput.value || "", 24, 36);
+}
+
+function haversineDistance(a, b) {
+  const R = 6371;
+  const dLat = toRadians(b.lat - a.lat);
+  const dLon = toRadians(b.lon - a.lon);
+  const lat1 = toRadians(a.lat);
+  const lat2 = toRadians(b.lat);
+  const sinLat = Math.sin(dLat / 2);
+  const sinLon = Math.sin(dLon / 2);
+  const c =
+    sinLat * sinLat +
+    Math.cos(lat1) * Math.cos(lat2) *
+      sinLon * sinLon;
+  const d = 2 * Math.atan2(Math.sqrt(c), Math.sqrt(1 - c));
+  return R * d;
+}
+
+function toRadians(deg) {
+  return (deg * Math.PI) / 180;
+}
+
+function buildTimeline() {
+  if (state.waypoints.length < 2) {
+    setStatus("Add at least two waypoints to animate.", "warning");
+    return null;
+  }
+  const speed = Math.max(parseFloat(speedInput.value) || 1, 0.1);
+  const startPause = Math.max(parseFloat(startPauseInput.value) || 0, 0);
+  const endPause = Math.max(parseFloat(endPauseInput.value) || 0, 0);
+
+  const segments = [];
+  let currentTime = 0;
+
+  if (startPause > 0) {
+    segments.push({
+      type: "pause",
+      at: state.waypoints[0],
+      duration: startPause,
+      start: currentTime,
+    });
+    currentTime += startPause;
+  }
+
+  for (let i = 0; i < state.waypoints.length - 1; i++) {
+    const from = state.waypoints[i];
+    const to = state.waypoints[i + 1];
+    const distance = haversineDistance(from, to);
+    const duration = (distance / speed) * 3600;
+    segments.push({
+      type: "move",
+      from,
+      to,
+      duration,
+      start: currentTime,
+    });
+    currentTime += duration;
+    const pause = Math.max(parseFloat(to.pause) || 0, 0);
+    if (pause > 0 && (i + 1) !== state.waypoints.length - 1) {
+      segments.push({
+        type: "pause",
+        at: to,
+        duration: pause,
+        start: currentTime,
+      });
+      currentTime += pause;
+    }
+  }
+
+  if (endPause > 0) {
+    segments.push({
+      type: "pause",
+      at: state.waypoints[state.waypoints.length - 1],
+      duration: endPause,
+      start: currentTime,
+    });
+    currentTime += endPause;
+  }
+
+  const totalDuration = currentTime;
+  return { segments, totalDuration };
+}
+
+function interpolatePosition(segment, elapsed) {
+  const t = Math.min(Math.max(elapsed / segment.duration, 0), 1);
+  const lat = segment.from.lat + (segment.to.lat - segment.from.lat) * t;
+  const lon = segment.from.lon + (segment.to.lon - segment.from.lon) * t;
+  return { lat, lon, t };
+}
+
+function headingBetween(from, to) {
+  const p1 = project(from.lat, from.lon, state.bounds);
+  const p2 = project(to.lat, to.lon, state.bounds);
+  return Math.atan2(p2.y - p1.y, p2.x - p1.x);
+}
+
+function runAnimation(record = false) {
+  const timeline = buildTimeline();
+  if (!timeline) return;
+  state.timeline = timeline;
+  state.bounds = computeBounds();
+  state.projectedWaypoints = state.waypoints.map((wp) => ({
+    ...wp,
+    ...project(wp.lat, wp.lon, state.bounds),
+  }));
+  const frameRate = Math.min(Math.max(parseFloat(frameRateInput.value) || 30, 1), 60);
+  const frameInterval = 1000 / frameRate;
+
+  let recorder = null;
+  let recordedChunks = [];
+  if (record) {
+    downloadPreview.hidden = true;
+  }
+  if (record) {
+    if (typeof MediaRecorder === "undefined") {
+      setStatus("MediaRecorder API is not supported in this browser.", "error");
+      return;
+    }
+    const stream = canvas.captureStream(frameRate);
+    const mimeTypes = [
+      "video/webm;codecs=vp9",
+      "video/webm;codecs=vp8",
+      "video/webm",
+    ];
+    let mimeType = mimeTypes.find((type) => MediaRecorder.isTypeSupported(type));
+    if (!mimeType) {
+      setStatus("This browser cannot export WebM recordings.", "error");
+      return;
+    }
+    recorder = new MediaRecorder(stream, { mimeType });
+    recorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) {
+        recordedChunks.push(event.data);
+      }
+    };
+    recorder.onstop = () => {
+      const blob = new Blob(recordedChunks, { type: recorder.mimeType });
+      const url = URL.createObjectURL(blob);
+      const fileName = `travelmap-${Date.now()}.webm`;
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName;
+      link.click();
+      downloadPreview.src = url;
+      downloadPreview.hidden = false;
+      downloadPreview.focus();
+      setStatus(`Download ready (${fileName}).`);
+    };
+    recorder.start();
+    recordedChunks = [];
+  }
+
+  let lastFrameTime = 0;
+  const startTime = performance.now();
+  const animation = {
+    timeline,
+    startTime,
+    frameInterval,
+    recorder,
+    record,
+    finished: false,
+  };
+  state.animation = animation;
+  disableControls(true);
+  setStatus(record ? "Recording animation..." : "Playing preview...");
+
+  function step(timestamp) {
+    if (!state.animation || animation.finished) return;
+    if (timestamp - lastFrameTime < frameInterval && !record) {
+      requestAnimationFrame(step);
+      return;
+    }
+    lastFrameTime = timestamp;
+    const elapsed = (timestamp - startTime) / 1000;
+    const { segments, totalDuration } = timeline;
+    if (elapsed >= totalDuration) {
+      drawFrame(segments, totalDuration);
+      finish();
+      return;
+    }
+    drawFrame(segments, elapsed);
+    requestAnimationFrame(step);
+  }
+
+  function finish() {
+    animation.finished = true;
+    disableControls(false);
+    setStatus(record ? "Finishing recording..." : "Preview finished.");
+    if (record && recorder) {
+      recorder.stop();
+    }
+    state.animation = null;
+    if (!record) {
+      drawStaticMap();
+    }
+  }
+
+  requestAnimationFrame(step);
+}
+
+function drawFrame(segments, elapsed) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, "#021224");
+  gradient.addColorStop(1, "#031a2f");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.save();
+  ctx.globalAlpha = 0.6;
+  ctx.fillStyle = "#142d47";
+  Object.values(CONTINENT_SHAPES).forEach((shape) => {
+    ctx.beginPath();
+    shape.forEach(([lat, lon], index) => {
+      const { x, y } = project(lat, lon, state.bounds);
+      if (index === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.closePath();
+    ctx.fill();
+  });
+  ctx.restore();
+
+  ctx.strokeStyle = "rgba(143, 211, 255, 0.2)";
+  ctx.lineWidth = 4;
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  state.projectedWaypoints.forEach((pt, index) => {
+    if (index === 0) ctx.moveTo(pt.x, pt.y);
+    else ctx.lineTo(pt.x, pt.y);
+  });
+  ctx.stroke();
+
+  const travelPath = buildTravelPath(segments, elapsed);
+  if (travelPath.length > 1) {
+    ctx.strokeStyle = "rgba(244, 94, 94, 0.85)";
+    ctx.lineWidth = 5;
+    ctx.beginPath();
+    travelPath.forEach((pt, index) => {
+      if (index === 0) ctx.moveTo(pt.x, pt.y);
+      else ctx.lineTo(pt.x, pt.y);
+    });
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = "#8fd3ff";
+  ctx.strokeStyle = "rgba(12, 42, 70, 0.7)";
+  ctx.lineWidth = 2;
+  state.projectedWaypoints.forEach((pt) => {
+    ctx.beginPath();
+    ctx.arc(pt.x, pt.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  });
+
+  const active = currentSegmentAt(segments, elapsed);
+  const vehicle = determineVehiclePosition(active, elapsed);
+  state.heading = vehicle.heading;
+
+  drawVehicle(vehicle.position, vehicle.heading);
+  drawUpcomingLine(vehicle.position, active);
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.85)";
+  ctx.font = "600 24px 'Inter', system-ui";
+  ctx.textAlign = "left";
+  ctx.fillText(titleInput.value || "", 24, 36);
+}
+
+function drawVehicle(position, heading) {
+  const point = project(position.lat, position.lon, state.bounds);
+  ctx.save();
+  ctx.translate(point.x, point.y);
+  ctx.rotate(heading);
+  if (state.iconImage) {
+    const scale = state.iconScale;
+    const size = 48 * scale;
+    ctx.drawImage(state.iconImage, -size / 2, -size / 2, size, size);
+  } else {
+    const radius = 18;
+    const gradient = ctx.createRadialGradient(0, 0, radius * 0.3, 0, 0, radius);
+    gradient.addColorStop(0, "#f9fffe");
+    gradient.addColorStop(1, DEFAULT_ICON_COLOUR);
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(0, 0, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
+    ctx.font = "bold 16px 'Inter', system-ui";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("GO", 0, 0);
+  }
+  ctx.restore();
+}
+
+function drawUpcomingLine(position, active) {
+  let segment = active;
+  if (!segment) return;
+  if (segment.type !== "move") {
+    segment = findNextMove(segment);
+    if (!segment) return;
+  }
+  const { lat, lon } = position;
+  const future = project(segment.to.lat, segment.to.lon, state.bounds);
+  const current = project(lat, lon, state.bounds);
+  ctx.strokeStyle = "rgba(83, 255, 178, 0.75)";
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.moveTo(current.x, current.y);
+  ctx.lineTo(future.x, future.y);
+  ctx.stroke();
+}
+
+function buildTravelPath(segments, elapsed) {
+  const path = [];
+  if (!segments.length) return path;
+  let lastPoint = null;
+  segments.forEach((segment) => {
+    if (segment.type !== "move") {
+      return;
+    }
+    if (segment.start + segment.duration <= elapsed) {
+      const from = project(segment.from.lat, segment.from.lon, state.bounds);
+      const to = project(segment.to.lat, segment.to.lon, state.bounds);
+      if (!lastPoint || lastPoint.x !== from.x || lastPoint.y !== from.y) {
+        path.push(from);
+      }
+      path.push(to);
+      lastPoint = to;
+    } else if (segment.start <= elapsed) {
+      const partial = interpolatePosition(segment, elapsed - segment.start);
+      const from = project(segment.from.lat, segment.from.lon, state.bounds);
+      if (!lastPoint || lastPoint.x !== from.x || lastPoint.y !== from.y) {
+        path.push(from);
+      }
+      path.push(project(partial.lat, partial.lon, state.bounds));
+      lastPoint = path[path.length - 1];
+    }
+  });
+  return path;
+}
+
+function currentSegmentAt(segments, elapsed) {
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i];
+    if (elapsed >= segment.start) {
+      return segment;
+    }
+  }
+  return segments[0];
+}
+
+function determineVehiclePosition(segment, elapsed) {
+  if (!segment) {
+    const first = state.waypoints[0];
+    return { position: first, heading: 0 };
+  }
+  if (segment.type === "pause") {
+    const previousMove = findPreviousMove(segment);
+    if (previousMove) {
+      const heading = headingBetween(previousMove.from, previousMove.to);
+      return { position: segment.at, heading };
+    }
+    const nextMove = findNextMove(segment);
+    if (nextMove) {
+      const heading = headingBetween(nextMove.from, nextMove.to);
+      return { position: segment.at, heading };
+    }
+    return { position: segment.at, heading: 0 };
+  }
+  const progress = interpolatePosition(segment, elapsed - segment.start);
+  const heading = headingBetween(segment.from, segment.to);
+  return { position: { lat: progress.lat, lon: progress.lon }, heading };
+}
+
+function findPreviousMove(segment) {
+  const segments = state.timeline?.segments || [];
+  const index = segments.indexOf(segment);
+  for (let i = index - 1; i >= 0; i--) {
+    if (segments[i].type === "move") return segments[i];
+  }
+  return null;
+}
+
+function findNextMove(segment) {
+  const segments = state.timeline?.segments || [];
+  const index = segments.indexOf(segment);
+  for (let i = index + 1; i < segments.length; i++) {
+    if (segments[i].type === "move") return segments[i];
+  }
+  return null;
+}
+
+function disableControls(disabled) {
+  [previewButton, downloadButton].forEach((button) => {
+    button.disabled = disabled;
+    button.classList.toggle("disabled", disabled);
+  });
+}
+
+previewButton.addEventListener("click", () => {
+  if (state.animation) return;
+  runAnimation(false);
+});
+
+downloadButton.addEventListener("click", () => {
+  if (state.animation) return;
+  runAnimation(true);
+});
+
+renderIconPreview();
+drawStaticMap();
+setStatus("Load a configuration or start adding waypoints.");

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Travel Map Animator (Web)</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Travel Map Animator (Web)</h1>
+      <p>
+        Upload a route configuration, customise the icon and export a browser-generated
+        animation of your journey.
+      </p>
+    </header>
+    <main>
+      <section class="controls">
+        <div class="panel">
+          <h2>Configuration</h2>
+          <label class="field">
+            <span>Configuration JSON</span>
+            <input type="file" id="configUpload" accept="application/json" />
+          </label>
+          <div class="field">
+            <label>
+              <span>Title</span>
+              <input type="text" id="titleInput" placeholder="My Adventure" />
+            </label>
+            <label>
+              <span>Speed (km/h)</span>
+              <input type="number" id="speedInput" value="80" min="1" />
+            </label>
+          </div>
+          <div class="field">
+            <label>
+              <span>Frame rate (fps)</span>
+              <input type="number" id="frameRateInput" value="30" min="1" max="60" />
+            </label>
+            <label>
+              <span>Start pause (s)</span>
+              <input type="number" id="startPauseInput" value="1" min="0" step="0.1" />
+            </label>
+            <label>
+              <span>End pause (s)</span>
+              <input type="number" id="endPauseInput" value="1" min="0" step="0.1" />
+            </label>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h2>Vehicle icon</h2>
+          <label class="field">
+            <span>Upload PNG icon</span>
+            <input type="file" id="iconUpload" accept="image/png" />
+          </label>
+          <canvas id="iconPreview" width="96" height="96" aria-label="Icon preview"></canvas>
+          <p class="hint">A default coloured circle will be used if no icon is supplied.</p>
+        </div>
+
+        <div class="panel">
+          <h2>Waypoints</h2>
+          <form id="waypointForm">
+            <div class="field">
+              <label>
+                <span>Name</span>
+                <input type="text" id="waypointName" required />
+              </label>
+              <label>
+                <span>Latitude</span>
+                <input type="number" id="waypointLat" step="0.0001" min="-90" max="90" required />
+              </label>
+              <label>
+                <span>Longitude</span>
+                <input type="number" id="waypointLon" step="0.0001" min="-180" max="180" required />
+              </label>
+              <label>
+                <span>Pause (s)</span>
+                <input type="number" id="waypointPause" step="0.1" min="0" value="1" />
+              </label>
+              <button type="submit" class="add">Add stop</button>
+            </div>
+          </form>
+          <table id="waypointTable" aria-label="Configured waypoints">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Name</th>
+                <th>Latitude</th>
+                <th>Longitude</th>
+                <th>Pause (s)</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+
+        <div class="panel actions">
+          <button id="previewButton" class="primary">Preview animation</button>
+          <button id="downloadButton" class="secondary">Download animation</button>
+        </div>
+      </section>
+
+      <section class="preview">
+        <div class="canvas-wrapper">
+          <canvas id="mapCanvas" width="960" height="540" aria-label="Map animation preview"></canvas>
+        </div>
+        <video id="downloadPreview" controls hidden></video>
+        <div class="status" id="status"></div>
+      </section>
+    </main>
+
+    <template id="waypointRowTemplate">
+      <tr>
+        <td class="index"></td>
+        <td class="name"></td>
+        <td class="lat"></td>
+        <td class="lon"></td>
+        <td class="pause"></td>
+        <td><button type="button" class="remove">Remove</button></td>
+      </tr>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,214 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: var(--background, #0b1623);
+  color: var(--text, #f0f4ff);
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(145deg, #07111b, #102237);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: #f0f4ff;
+}
+
+header {
+  padding: 2rem clamp(1rem, 4vw, 3rem) 1rem;
+  text-align: center;
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+header p {
+  margin: 0 auto;
+  max-width: 60ch;
+  opacity: 0.85;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 clamp(1rem, 4vw, 3rem) 3rem;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+}
+
+@media (max-width: 960px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(16, 36, 58, 0.75);
+  border: 1px solid rgba(67, 120, 176, 0.45);
+  border-radius: 16px;
+  padding: 1.2rem;
+  box-shadow: 0 18px 32px rgba(3, 10, 20, 0.35);
+}
+
+.panel h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.field {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  align-items: flex-end;
+}
+
+.field label {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 130px;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.field input[type="text"],
+.field input[type="number"],
+.field input[type="file"] {
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid rgba(140, 175, 220, 0.4);
+  background: rgba(2, 12, 24, 0.55);
+  color: inherit;
+}
+
+.field input[type="file"] {
+  padding: 0.4rem 0.7rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(83, 169, 255, 0.85);
+  color: #07111b;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled,
+button.disabled {
+  opacity: 0.5;
+  cursor: progress;
+  box-shadow: none;
+}
+
+button:hover,
+button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(15, 110, 197, 0.35);
+}
+
+button.secondary {
+  background: rgba(129, 216, 142, 0.85);
+}
+
+button.add {
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+button.remove {
+  background: rgba(255, 123, 123, 0.8);
+  padding: 0.4rem 0.8rem;
+}
+
+.panel.actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.hint {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+#iconPreview {
+  margin-top: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 16px;
+  border: 1px dashed rgba(140, 175, 220, 0.4);
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.canvas-wrapper {
+  background: rgba(1, 9, 18, 0.65);
+  padding: 1rem;
+  border-radius: 22px;
+  box-shadow: inset 0 0 0 1px rgba(67, 120, 176, 0.45), 0 24px 40px rgba(3, 10, 20, 0.45);
+}
+
+#mapCanvas {
+  width: min(100%, 960px);
+  height: auto;
+  display: block;
+  border-radius: 12px;
+  background: radial-gradient(circle at 50% 35%, rgba(34, 81, 134, 0.5), rgba(3, 12, 24, 0.85));
+}
+
+#waypointTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+#waypointTable th,
+#waypointTable td {
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(140, 175, 220, 0.2);
+}
+
+#waypointTable tbody tr:hover {
+  background: rgba(83, 169, 255, 0.1);
+}
+
+.status {
+  min-height: 1.5rem;
+  font-size: 0.85rem;
+  opacity: 0.8;
+  text-align: center;
+}
+
+.status[data-type="error"] {
+  color: #ffb3b3;
+}
+
+.status[data-type="warning"] {
+  color: #ffe59a;
+}
+
+.status[data-type="info"] {
+  color: #cde7ff;
+}
+
+video#downloadPreview {
+  width: min(100%, 480px);
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(3, 10, 20, 0.4);
+}


### PR DESCRIPTION
## Summary
- add a standalone web UI for building itineraries and previewing the animation
- support icon uploads plus MediaRecorder-based WebM downloads directly in the browser
- document how to serve the new web application in the README

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de50e04df4832f890f927f06fc4583