### PR TITLE
Improve route animation playback

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -82,6 +82,10 @@
                 <option value="1" selected>1× (Normal)</option>
                 <option value="2">2× (Fast)</option>
                 <option value="4">4× (Rapid)</option>
+                <option value="8">8× (Express)</option>
+                <option value="10">10× (Swift)</option>
+                <option value="15">15× (Blazing)</option>
+                <option value="20">20× (Lightning)</option>
               </select>
             </label>
             <div class="animation-actions">


### PR DESCRIPTION
## Summary
- add higher animation speed presets up to 20× in the controls
- keep the vehicle marker centered on the map while the animation plays
- expand animation recording support with WebM fallbacks and automatic file extensions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6dd85154832fae6cdc8f41e082da