### PR TITLE
Add ffmpeg dependency and improve export error message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 imageio>=2.26
+imageio-ffmpeg>=0.4
 matplotlib>=3.7
 numpy>=1.24
 Pillow>=9.0

--- a/travelmap/renderer.py
+++ b/travelmap/renderer.py
@@ -252,14 +252,23 @@ class TravelMapAnimator:
         output_path = Path(self.config.output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with imageio.get_writer(
-            output_path,
-            fps=self.config.frame_rate,
-            codec="libx264",
-            format="FFMPEG",
-            macro_block_size=None,
-            quality=8,
-        ) as writer:
+        try:
+            writer_ctx = imageio.get_writer(
+                output_path,
+                fps=self.config.frame_rate,
+                codec="libx264",
+                format="FFMPEG",
+                macro_block_size=None,
+                quality=8,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "FFMPEG support is required to export videos. Install the "
+                "'imageio-ffmpeg' package (for example via 'pip install "
+                "imageio-ffmpeg') and try again."
+            ) from exc
+
+        with writer_ctx as writer:
             for frame in self._frame_states:
                 self._draw_frame(frame)
                 self._fig.canvas.draw()


### PR DESCRIPTION
## Summary
- ensure the imageio ffmpeg plugin is installed by default by adding imageio-ffmpeg to the requirements
- catch missing ffmpeg support when opening the video writer and raise a clearer installation hint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de785f782c832fa34130261acda8f7