### PR TITLE
Add cache-busting version display

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -785,6 +785,13 @@ function createDefaultVehicleIcons() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+  const versionElement = document.getElementById("appVersion");
+  const version = window.APP_VERSION ?? "dev-build";
+  if (versionElement) {
+    versionElement.textContent = version;
+  }
+  console.info(`Travel Map Planner version: ${version}`);
+
   initialiseForm();
   initialiseVehicleIconUploads();
   initialiseAnimationControls();

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,22 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Travel Map Planner</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" id="mainStylesheet" />
+    <script>
+      (function () {
+        const modifiedText = document.lastModified;
+        const parsed = modifiedText ? new Date(modifiedText) : null;
+        const version = parsed && !Number.isNaN(parsed.valueOf()) ? parsed.toISOString() : new Date().toISOString();
+
+        window.APP_VERSION = version;
+        document.documentElement.setAttribute("data-app-version", version);
+
+        const stylesheet = document.getElementById("mainStylesheet");
+        if (stylesheet) {
+          stylesheet.href = `style.css?v=${encodeURIComponent(version)}`;
+        }
+      })();
+    </script>
   </head>
   <body>
     <header>
@@ -13,6 +28,9 @@
         Plan your journey by entering a start point, any number of waypoints and a final
         destination. Routes are rendered with Google Maps for accurate turn-by-turn
         directions.
+      </p>
+      <p class="version-label" aria-live="polite">
+        Version: <span id="appVersion">Loading…</span>
       </p>
     </header>
     <main>
@@ -113,9 +131,19 @@
         <div id="map" role="region" aria-label="Route map"></div>
       </section>
     </main>
-    <script src="app.js"></script>
+    <script>
+      (function () {
+        const version = window.APP_VERSION || new Date().toISOString();
+        const versionElement = document.getElementById("appVersion");
+        if (versionElement) {
+          versionElement.textContent = version;
+        }
+
+        const scriptSrc = `app.js?v=${encodeURIComponent(version)}`;
+        document.write(`<script src="${scriptSrc}"><\/script>`);
+      })();
+    </script>
     <script
-      async
       defer
       src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBEQXlNW6hW-F_VqL9OVtt3YABfl545MkU&callback=initMap&libraries=geometry"
     ></script>

--- a/web/style.css
+++ b/web/style.css
@@ -30,6 +30,20 @@ header p {
   opacity: 0.85;
 }
 
+.version-label {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.version-label span {
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace;
+  background: rgba(7, 17, 27, 0.55);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(140, 175, 220, 0.35);
+}
+
 main {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- add automatic ISO timestamp versioning that appends cache-busting query parameters to the CSS and JavaScript assets
- surface the current build version in the UI header and console for quick verification

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68de7a9f47cc832f8424a0a825d3921f