### PR TITLE
Add high speed options and keyboard shortcut for animation

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -30,6 +30,21 @@ const animationControls = {
 const baseAnimationSpeed = 65;
 let animationSpeedMultiplier = 1;
 
+function isEditableElement(element) {
+  if (!element) return false;
+  if (element.isContentEditable) return true;
+
+  const editableSelector = "input, textarea, select, [contenteditable='true']";
+  if (typeof element.closest === "function" && element.closest(editableSelector)) {
+    return true;
+  }
+
+  const tagName = element.tagName;
+  if (!tagName) return false;
+
+  return ["INPUT", "TEXTAREA", "SELECT", "BUTTON"].includes(tagName);
+}
+
 function setStatus(message, type = "info") {
   const statusEl = document.getElementById("routeStatus");
   if (!statusEl) return;
@@ -319,6 +334,25 @@ function initialiseAnimationControls() {
   });
 
   updateAnimationButtons();
+}
+
+function initialiseKeyboardShortcuts() {
+  document.addEventListener("keydown", (event) => {
+    if (event.defaultPrevented) return;
+    const isSpacebar = event.code === "Space" || event.key === " ";
+    if (!isSpacebar) return;
+    if (event.repeat) {
+      event.preventDefault();
+      return;
+    }
+    if (isEditableElement(event.target)) return;
+    if (!animationControls.enableCheckbox?.checked) return;
+    if (!currentRouteSegments.length) return;
+    if (animationState) return;
+
+    event.preventDefault();
+    startRouteAnimation({ record: false });
+  });
 }
 
 function initialiseMapTypeControl() {
@@ -795,6 +829,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initialiseForm();
   initialiseVehicleIconUploads();
   initialiseAnimationControls();
+  initialiseKeyboardShortcuts();
   initialiseMapTypeControl();
 });
 

--- a/web/index.html
+++ b/web/index.html
@@ -104,6 +104,9 @@
                 <option value="10">10× (Swift)</option>
                 <option value="15">15× (Blazing)</option>
                 <option value="20">20× (Lightning)</option>
+                <option value="50">50× (Warp)</option>
+                <option value="75">75× (Ludicrous)</option>
+                <option value="100">100× (Hypersonic)</option>
               </select>
             </label>
             <div class="animation-actions">


### PR DESCRIPTION
## Summary
- add new 50×, 75×, and 100× animation speed options to the UI selector
- allow starting the route animation with the spacebar when animation is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7d3bdfac832faea28f0003be4bac