### PR TITLE
Add 500x animation speed option

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -107,6 +107,7 @@
                 <option value="50">50× (Warp)</option>
                 <option value="75">75× (Ludicrous)</option>
                 <option value="100">100× (Hypersonic)</option>
+                <option value="500">500× (Lightspeed)</option>
               </select>
             </label>
             <div class="animation-actions">


### PR DESCRIPTION
## Summary
- add a 500× (Lightspeed) option to the animation speed selector for rapid previews

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de7f8e6dc8832f8452fd7035179d64