### PR TITLE
Prefer WebM output for recordings

### DIFF
--- a/travelmap/config.py
+++ b/travelmap/config.py
@@ -56,7 +56,7 @@ class AnimationConfig:
     description: Optional[str] = None
     speed_kmh: float = 80.0
     frame_rate: int = 30
-    output_path: Path = Path("travelmap.mp4")
+    output_path: Path = Path("travelmap.webm")
     width: int = 1920
     height: int = 1080
     margin_degrees: float = 5.0
@@ -76,7 +76,7 @@ class AnimationConfig:
         if len(waypoints) < 2:
             raise ValueError("At least two waypoints are required to build an itinerary.")
 
-        output_path = data.get("output") or data.get("output_path") or "travelmap.mp4"
+        output_path = data.get("output") or data.get("output_path") or "travelmap.webm"
 
         return AnimationConfig(
             title=data.get("title", ""),

--- a/travelmap/examples/sample_trip.json
+++ b/travelmap/examples/sample_trip.json
@@ -15,5 +15,5 @@
     {"name": "Rome", "lat": 41.9028, "lon": 12.4964, "pause": 0.5},
     {"name": "Athens", "lat": 37.9838, "lon": 23.7275, "pause": 1.0}
   ],
-  "output": "output/european_adventure.mp4"
+  "output": "output/european_adventure.webm"
 }

--- a/web/app.js
+++ b/web/app.js
@@ -634,12 +634,12 @@ function createAnimationRecorder() {
     return null;
   }
   const preferredTypes = [
-    "video/mp4;codecs=avc1.42E01E,mp4a.40.2",
-    "video/mp4;codecs=h264,aac",
-    "video/mp4",
     "video/webm;codecs=vp9,opus",
     "video/webm;codecs=vp8,opus",
     "video/webm",
+    "video/mp4;codecs=avc1.42E01E,mp4a.40.2",
+    "video/mp4;codecs=h264,aac",
+    "video/mp4",
   ];
   let mimeType = null;
   for (const type of preferredTypes) {
@@ -780,7 +780,7 @@ function saveRecording(recording) {
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  const extension = recording.mimeType.includes("mp4") ? "mp4" : "webm";
+  const extension = recording.mimeType.includes("webm") ? "webm" : "mp4";
   link.download = `travelmap-animation-${Date.now()}.${extension}`;
   document.body.appendChild(link);
   link.click();


### PR DESCRIPTION
## Summary
- default animation output now points to a `.webm` file and the sample configuration matches
- prioritize WebM encodings when capturing browser recordings and ensure downloaded files adopt the correct extension

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de807eaecc832fa44939b54aa52306