### PR TITLE
Fix map recording to capture WebM output

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -112,7 +112,7 @@
             </label>
             <div class="animation-actions">
               <button type="button" id="previewAnimationButton" class="secondary">Preview animation</button>
-              <button type="button" id="downloadAnimationButton">Download animation (MP4)</button>
+              <button type="button" id="downloadAnimationButton">Download animation (WebM)</button>
             </div>
           </div>
           <div class="field actions">


### PR DESCRIPTION
## Summary
- ensure the animation recorder targets the visible Google Maps canvas and validates that a video track is available before recording
- restrict recording to WebM encodings and always download files with a .webm extension
- update the download button label to indicate the WebM format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de81dbdb00832f87f417c2e344de0f