### PR TITLE
Add browser config script for Google Maps key

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The resulting video is written to the `output` path defined in your configuratio
 
 ## Browser-based animator
 
-A lightweight web interface is bundled in the [`web/`](web/) directory. Serve the folder with any static file server (for example `python -m http.server` from the repository root) and open `http://localhost:8000/web/` in your browser. Configure your Google Maps access by setting `GOOGLE_MAPS_API_KEY` inside [`web/.env`](web/.env). The page lets you:
+A lightweight web interface is bundled in the [`web/`](web/) directory. Serve the folder with any static file server (for example `python -m http.server` from the repository root) and open `http://localhost:8000/web/` in your browser. Configure your Google Maps access by either exposing a [`web/.env`](web/.env) file or, for hosts that block dotfiles (such as GitHub Pages), by updating [`web/config.js`](web/config.js) to set `window.GMAPS_API_KEY` with your key before deploying. The page lets you:
 
 - Load an existing itinerary JSON file that matches the CLI configuration schema.
 - Add or remove waypoints manually and adjust animation settings such as speed, frame rate and pauses.

--- a/web/config.js
+++ b/web/config.js
@@ -1,0 +1,14 @@
+(function () {
+  const placeholderKey = "YOUR_API_KEY";
+  if (!window.GMAPS_API_KEY || window.GMAPS_API_KEY === placeholderKey) {
+    window.GMAPS_API_KEY = placeholderKey;
+  }
+
+  if (window.GMAPS_API_KEY === placeholderKey) {
+    console.warn(
+      "Update web/config.js with your Google Maps API key before deploying to production."
+    );
+  }
+})();
+
+// Replace "YOUR_API_KEY" with your Google Maps API key prior to publishing the site.

--- a/web/index.html
+++ b/web/index.html
@@ -138,6 +138,13 @@
     <script>
       (function () {
         const version = window.APP_VERSION || new Date().toISOString();
+        const configSrc = `config.js?v=${encodeURIComponent(version)}`;
+        document.write(`<script src="${configSrc}" data-config-loader="true"><\\/script>`);
+      })();
+    </script>
+    <script>
+      (function () {
+        const version = window.APP_VERSION || new Date().toISOString();
         const versionElement = document.getElementById("appVersion");
         if (versionElement) {
           versionElement.textContent = version;


### PR DESCRIPTION
## Summary
- load a new config.js helper before the main bundle so static hosts can expose the Google Maps API key without dotfiles
- provide a placeholder config.js implementation that sets window.GMAPS_API_KEY and warns when it needs updating
- document the alternate configuration path for hosts like GitHub Pages in the README

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dee54fd318832f9ebcc361224ffc40