### PR TITLE
Fix Google Maps key config script to avoid ReferenceError

### DIFF
--- a/web/config.js
+++ b/web/config.js
@@ -1,14 +1,17 @@
 (function () {
   const placeholderKey = "YOUR_API_KEY";
-  if (!window.GMAPS_API_KEY || window.GMAPS_API_KEY === placeholderKey) {
-    window.GMAPS_API_KEY = placeholderKey;
+  const configuredKey =
+    typeof window.GMAPS_API_KEY === "string" ? window.GMAPS_API_KEY.trim() : "";
+
+  if (configuredKey && configuredKey !== placeholderKey) {
+    window.GMAPS_API_KEY = configuredKey;
+    return;
   }
 
-  if (window.GMAPS_API_KEY === AIzaSyCEjHTmqVn-72tx1XHcDatsLIRBW8Xeamw) {
-    console.warn(
-      "Update web/config.js with your Google Maps API key before deploying to production."
-    );
-  }
+  console.warn(
+    "Google Maps API key is not configured. Update web/.env or web/config.js before deploying."
+  );
+  window.GMAPS_API_KEY = placeholderKey;
 })();
 
 // Replace "YOUR_API_KEY" with your Google Maps API key prior to publishing the site.


### PR DESCRIPTION
## Summary
- ensure the Google Maps API key bootstrapper gracefully handles missing or placeholder keys
- restore the placeholder value and warn when no key is configured instead of throwing a ReferenceError

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68deead9b878832fabb7199a39307b52