### PR TITLE
Fix placeholder Google Maps API key syntax

### DIFF
--- a/web/config.js
+++ b/web/config.js
@@ -1,5 +1,5 @@
 (function () {
-  const placeholderKey = AIzaSyCEjHTmqVn-72tx1XHcDatsLIRBW8Xeamw;
+  const placeholderKey = "AIzaSyCEjHTmqVn-72tx1XHcDatsLIRBW8Xeamw";
   const configuredKey =
     typeof window.GMAPS_API_KEY === "string" ? window.GMAPS_API_KEY.trim() : "";
 


### PR DESCRIPTION
## Summary
- wrap the placeholder Google Maps API key in quotes so `config.js` is valid JavaScript
- ensure the fallback configuration executes so the app version, icon previews, and map bootstrap scripts can run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8877e414832faaf01f70dc15e9df