### PR TITLE
Ensure application initialises after deferred script load

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1532,7 +1532,7 @@ async function bootstrapGoogleMaps() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+function startApplication() {
   const versionElement = document.getElementById("appVersion");
   const version = window.APP_VERSION ?? "dev-build";
   if (versionElement) {
@@ -1547,7 +1547,13 @@ document.addEventListener("DOMContentLoaded", () => {
   initialiseMapTypeControl();
 
   void bootstrapGoogleMaps();
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", startApplication, { once: true });
+} else {
+  startApplication();
+}
 
 window.initMap = function initMap() {
   const mapElement = document.getElementById("map");


### PR DESCRIPTION
## Summary
- ensure the app initialisation routine runs even when app.js loads after DOMContentLoaded
- reuse the same setup logic when the document is already ready

## Testing
- not run (frontend change)

------
https://chatgpt.com/codex/tasks/task_e_68df8ec46778832fb06704c3564e1f7d