### PR TITLE
Switch fuel pricing to litres

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ A lightweight web interface is bundled in the [`web/`](web/) directory. Serve th
 | `vehicle.icon` | string | Optional path to a custom PNG icon. Icons are rotated to match the current bearing. |
 | `vehicle.icon_scale` | number | Relative scaling factor applied to the icon. |
 | `vehicle.mpg` / `vehicle.fuel_efficiency_mpg` | number | Optional vehicle efficiency in miles-per-gallon used for fuel estimates. |
-| `vehicle.fuel_price` / `vehicle.fuel_price_per_gallon` | number | Optional default fuel price per gallon for the itinerary. |
+| `vehicle.fuel_price` / `vehicle.fuel_price_per_litre` | number | Optional default fuel price per litre for the itinerary. Use `fuel_price_per_litre` for new configs; legacy `fuel_price` / `fuel_price_per_gallon` values are converted automatically. |
 | `waypoints` | list | Ordered list of stop dictionaries containing `name`, `lat`, `lon` and optional `pause` seconds. |
-| `waypoints[].fuel_price` / `waypoints[].fuel_price_per_gallon` | number | Optional override fuel price for legs that depart from the waypoint. |
+| `waypoints[].fuel_price` / `waypoints[].fuel_price_per_litre` | number | Optional override fuel price per litre for legs that depart from the waypoint (legacy gallon values remain supported). |
 | `output` | string | MP4 path to write (parent directories are created automatically). |
 | `currency_symbol` | string | Optional currency symbol used when displaying estimated fuel costs (default `$`). |
 | `summary_display_seconds` | number | Duration in seconds to display the end-of-trip mileage and fuel summary (default `2.0`). |

--- a/travelmap/renderer.py
+++ b/travelmap/renderer.py
@@ -22,6 +22,7 @@ from .map_shapes import iter_shapes
 
 Coordinate = Tuple[float, float]
 MILES_PER_KM = 0.621371
+LITRES_PER_GALLON = 3.785411784
 
 
 @dataclass
@@ -38,7 +39,7 @@ class LegSummary:
     start_name: str
     end_name: str
     distance_miles: float
-    fuel_price_per_gallon: Optional[float]
+    fuel_price_per_litre: Optional[float]
     fuel_cost: Optional[float]
 
 
@@ -174,18 +175,19 @@ class TravelMapAnimator:
         total_cost = 0.0
         cost_available = False
         mpg = self.config.vehicle.fuel_efficiency_mpg
-        default_price = self.config.vehicle.fuel_price_per_gallon
+        default_price = self.config.vehicle.fuel_price_per_litre
 
         for start, end in zip(waypoints[:-1], waypoints[1:]):
             distance_km = haversine_km((start.latitude, start.longitude), (end.latitude, end.longitude))
             distance_miles = distance_km * MILES_PER_KM
             total_distance += distance_miles
 
-            price = start.fuel_price_per_gallon if start.fuel_price_per_gallon is not None else default_price
+            price = start.fuel_price_per_litre if start.fuel_price_per_litre is not None else default_price
             fuel_cost: Optional[float] = None
             if mpg and mpg > 0 and price is not None:
                 gallons_needed = distance_miles / mpg
-                fuel_cost = gallons_needed * price
+                litres_needed = gallons_needed * LITRES_PER_GALLON
+                fuel_cost = litres_needed * price
                 total_cost += fuel_cost
                 cost_available = True
 
@@ -194,7 +196,7 @@ class TravelMapAnimator:
                     start_name=start.name,
                     end_name=end.name,
                     distance_miles=distance_miles,
-                    fuel_price_per_gallon=price,
+                    fuel_price_per_litre=price,
                     fuel_cost=fuel_cost,
                 )
             )
@@ -211,12 +213,12 @@ class TravelMapAnimator:
             if leg.fuel_cost is not None:
                 line += f" | est. cost {self.config.currency_symbol}{leg.fuel_cost:.2f}"
             elif (
-                leg.fuel_price_per_gallon is not None
+                leg.fuel_price_per_litre is not None
                 and self.config.vehicle.fuel_efficiency_mpg
                 and self.config.vehicle.fuel_efficiency_mpg > 0
             ):
                 line += (
-                    f" | price {self.config.currency_symbol}{leg.fuel_price_per_gallon:.2f}/gal"
+                    f" | price {self.config.currency_symbol}{leg.fuel_price_per_litre:.2f}/L"
                 )
             lines.append(line)
 

--- a/web/index.html
+++ b/web/index.html
@@ -94,13 +94,13 @@
                 />
               </label>
               <label for="fuelPriceInput">
-                <span>Fuel price per gallon</span>
+                <span>Fuel price per litre</span>
                 <input
                   type="number"
                   id="fuelPriceInput"
                   min="0"
                   step="0.01"
-                  placeholder="e.g. 4.25"
+                  placeholder="e.g. 1.45"
                   inputmode="decimal"
                 />
               </label>


### PR DESCRIPTION
## Summary
- update configuration loading, renderer logic, and the web UI to work with fuel prices per litre while converting legacy per-gallon values
- adjust client-side route summaries to display litre usage and compute fuel costs using the new unit
- document the revised configuration options in the README for clarity

## Testing
- python -m compileall travelmap

------
https://chatgpt.com/codex/tasks/task_e_68dfdead2a88832fb4f9a9c3eaafd993